### PR TITLE
Add an option to hide player positions

### DIFF
--- a/common/src/main/java/net/pl3x/map/configuration/PlayerTracker.java
+++ b/common/src/main/java/net/pl3x/map/configuration/PlayerTracker.java
@@ -22,10 +22,14 @@ public final class PlayerTracker extends AbstractConfig {
     @Key("settings.hide.invisible")
     @Comment("Should invisible players be hidden from the map")
     public static boolean HIDE_INVISIBLE = true;
-
+    
     @Key("settings.hide.spectators")
     @Comment("Should spectators be hidden from the map")
     public static boolean HIDE_SPECTATORS = true;
+    
+    @Key("settings.hide.position")
+    @Comment("Should player positions be hidden from the map")
+    public static boolean HIDE_POSITION = true;
 
     @Key("settings.tooltip")
     @Comment("""

--- a/common/src/main/java/net/pl3x/map/configuration/PlayerTracker.java
+++ b/common/src/main/java/net/pl3x/map/configuration/PlayerTracker.java
@@ -22,7 +22,7 @@ public final class PlayerTracker extends AbstractConfig {
     @Key("settings.hide.invisible")
     @Comment("Should invisible players be hidden from the map")
     public static boolean HIDE_INVISIBLE = true;
-    
+
     @Key("settings.hide.spectators")
     @Comment("Should spectators be hidden from the map")
     public static boolean HIDE_SPECTATORS = true;

--- a/common/src/main/java/net/pl3x/map/configuration/PlayerTracker.java
+++ b/common/src/main/java/net/pl3x/map/configuration/PlayerTracker.java
@@ -26,7 +26,7 @@ public final class PlayerTracker extends AbstractConfig {
     @Key("settings.hide.spectators")
     @Comment("Should spectators be hidden from the map")
     public static boolean HIDE_SPECTATORS = true;
-    
+
     @Key("settings.hide.position")
     @Comment("Should player positions be hidden from the map")
     public static boolean HIDE_POSITION = true;

--- a/common/src/main/java/net/pl3x/map/markers/layer/PlayersLayer.java
+++ b/common/src/main/java/net/pl3x/map/markers/layer/PlayersLayer.java
@@ -74,6 +74,9 @@ public class PlayersLayer extends WorldLayer {
             if (player.isNPC()) {
                 return;
             }
+            if (PlayerTracker.HIDE_POSITION) {
+                return;
+            }
             if (PlayerTracker.HIDE_INVISIBLE && player.isInvisible()) {
                 return;
             }

--- a/common/src/main/java/net/pl3x/map/task/UpdateSettingsData.java
+++ b/common/src/main/java/net/pl3x/map/task/UpdateSettingsData.java
@@ -54,6 +54,9 @@ public class UpdateSettingsData implements Runnable {
             } else if (PlayerTracker.HIDE_INVISIBLE && player.isInvisible()) {
                 worldName = null;
                 position = null;
+            } else if (PlayerTracker.HIDE_POSITION) {
+                worldName = null;
+                position = null;
             }
 
             Map<String, Object> entry = new LinkedHashMap<>();


### PR DESCRIPTION
Currently, it isn't possible to hide player positions from the map. This causes issues in servers where exact player locations can be used as an advantage, or when player positions are not desired to be shown on the map. This pull request adds an option at `hide.position` which specifies whether to hide player positions from the map, and prevent them from being sent to the map.