### PR TITLE
add swm to softdepend of plugin

### DIFF
--- a/paper/src/main/resources/plugin.yml
+++ b/paper/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ api-version: "1.19"
 author: "BillyGalbreath"
 description: "${description}"
 website: "${website}"
+softdepend: [SlimeWorldManager]
 
 permissions:
   pl3xmap.command.map:


### PR DESCRIPTION
Adding SlimeWorldManager as soft dependcy of the plugin makes it so that it successfully loads SWM managed worlds and doesn't produce exceptions with unloaded world.

fixes #138 