### PR TITLE
fix invalid getWorldSurfaceY() computation

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/world/ChunkAnvil118.java
+++ b/core/src/main/java/net/pl3x/map/core/world/ChunkAnvil118.java
@@ -115,7 +115,7 @@ public class ChunkAnvil118 extends Chunk {
         if (noHeightmap()) {
             return getWorld().getMinBuildHeight();
         }
-        return heightmap(getWorld().getMaxBuildHeight(), this.worldSurfaceHeights).get((z & 0xF) << 4) + (x & 0xF);
+        return heightmap(getWorld().getMaxBuildHeight(), this.worldSurfaceHeights).get(((z & 0xF) << 4) + (x & 0xF));
     }
 
     private @Nullable Section getSection(int y) {


### PR DESCRIPTION
Heightmap getter was not called correctly, thus messing up block rendering. This was especially noticeable in the End.

Before:

![image](https://github.com/BillyGalbreath/Pl3xMap/assets/1063127/ee94f689-def3-4201-8e9b-b713ee56baca)

After:

![image](https://github.com/BillyGalbreath/Pl3xMap/assets/1063127/67d269a7-cfd6-4025-8bef-db46a881954d)
