### PR TITLE
Change comment to use 'jpg' instead of 'jpeg'

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/configuration/Config.java
+++ b/core/src/main/java/net/pl3x/map/core/configuration/Config.java
@@ -63,7 +63,7 @@ public final class Config extends AbstractConfig {
     @Key("settings.web-directory.tile-format")
     @Comment("""
             The image format for tile images.
-            Built in types: bmp, gif, jpeg, png""")
+            Built in types: bmp, gif, jpg, png""")
     public static String WEB_TILE_FORMAT = "png";
     @Key("settings.web-directory.tile-quality")
     @Comment("""


### PR DESCRIPTION
'jpeg' is not a valid option in the config, this adjusts the comment to say 'jpg' instead