### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/world/Chunk.java
+++ b/core/src/main/java/net/pl3x/map/core/world/Chunk.java
@@ -198,7 +198,7 @@ public abstract class Chunk {
     }
 
     public static @NotNull Chunk create(@NotNull World world, @NotNull Region region, @NotNull CompoundTag tag, int index) {
-        // https://minecraft.fandom.com/wiki/Data_version#List_of_data_versions
+        // https://minecraft.wiki/w/Data_version#List_of_data_versions
         int version = tag.getInt("DataVersion");
         Chunk chunk;
         if (version < 1519) chunk = new EmptyChunk(world, region); // wtf, older than 1.13


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.