### PR TITLE
use bit masking instead of bit shifting

### DIFF
--- a/webmap/src/palette/Block.ts
+++ b/webmap/src/palette/Block.ts
@@ -6,8 +6,8 @@ export class Block {
 
     constructor(packed: number, minY: number) {
         this._block = packed >>> 22;
-        this._biome = (packed << 10) >> 22;
-        this._yPos = ((packed << 20) >> 20);
+        this._biome = (packed & 0b0000000000_1111111111_000000000000) >>> 12;
+        this._yPos = packed & 0b0000000000_0000000000_111111111111;
         this._minY = minY;
     }
 


### PR DESCRIPTION
This is more user readable and makes sure we don't have to deal with any unintentional negative numbers or overflowing numbers