### PR TITLE
Use SSE Events to push realtime data from the internal server to the webmap

### DIFF
--- a/bukkit/src/main/java/net/pl3x/map/bukkit/Pl3xMapBukkit.java
+++ b/bukkit/src/main/java/net/pl3x/map/bukkit/Pl3xMapBukkit.java
@@ -81,7 +81,7 @@ public class Pl3xMapBukkit extends JavaPlugin implements Listener {
         }
 
         getServer().getScheduler().runTaskTimer(this, () ->
-                this.pl3xmap.getScheduler().tick(), 20, 20);
+                this.pl3xmap.getScheduler().tick(), 20, 1);
     }
 
     @Override

--- a/core/src/main/java/net/pl3x/map/core/configuration/Config.java
+++ b/core/src/main/java/net/pl3x/map/core/configuration/Config.java
@@ -35,6 +35,11 @@ public final class Config extends AbstractConfig {
             Extra logger/console output. (can be spammy)""")
     public static boolean DEBUG_MODE = false;
 
+    @Key("settings.use-sse-events")
+    @Comment("""
+            Enable the use of SSE events to make markers update in real time.""")
+    public static boolean SSE_EVENTS = true;
+
     @Key("settings.language-file")
     @Comment("""
             The language file to use from the locale folder.""")

--- a/core/src/main/java/net/pl3x/map/core/markers/layer/Layer.java
+++ b/core/src/main/java/net/pl3x/map/core/markers/layer/Layer.java
@@ -41,7 +41,7 @@ import org.jetbrains.annotations.Nullable;
 @SuppressWarnings("UnusedReturnValue")
 public abstract class Layer extends Keyed implements JsonSerializable {
     private Supplier<@NotNull String> labelSupplier;
-    private int updateInterval = 15;
+    private int updateInterval = 15 * 20;
     private boolean showControls = true;
     private boolean defaultHidden = false;
     private int priority = 99;
@@ -93,7 +93,7 @@ public abstract class Layer extends Keyed implements JsonSerializable {
     }
 
     /**
-     * Get this layer's update interval (in seconds).
+     * Get this layer's update interval (in ticks).
      *
      * @return update interval
      */
@@ -102,7 +102,7 @@ public abstract class Layer extends Keyed implements JsonSerializable {
     }
 
     /**
-     * Set this layer's update interval (in seconds).
+     * Set this layer's update interval (in ticks).
      *
      * @param updateInterval new update interval
      * @return this layer

--- a/core/src/main/java/net/pl3x/map/core/markers/layer/SpawnLayer.java
+++ b/core/src/main/java/net/pl3x/map/core/markers/layer/SpawnLayer.java
@@ -65,7 +65,7 @@ public class SpawnLayer extends WorldLayer {
             throw new RuntimeException(e);
         }
 
-        setUpdateInterval(30);
+        setUpdateInterval(30 * 20);
         setShowControls(SpawnLayerConfig.SHOW_CONTROLS);
         setDefaultHidden(SpawnLayerConfig.DEFAULT_HIDDEN);
         setPriority(SpawnLayerConfig.PRIORITY);

--- a/core/src/main/java/net/pl3x/map/core/markers/layer/WorldBorderLayer.java
+++ b/core/src/main/java/net/pl3x/map/core/markers/layer/WorldBorderLayer.java
@@ -52,7 +52,7 @@ public class WorldBorderLayer extends WorldLayer {
      */
     public WorldBorderLayer(@NotNull World world) {
         this(KEY, world, () -> Lang.UI_LAYER_WORLDBORDER);
-        setUpdateInterval(30);
+        setUpdateInterval(30 * 20);
         setShowControls(WorldBorderLayerConfig.SHOW_CONTROLS);
         setDefaultHidden(WorldBorderLayerConfig.DEFAULT_HIDDEN);
         setPriority(WorldBorderLayerConfig.PRIORITY);

--- a/core/src/main/java/net/pl3x/map/core/registry/WorldRegistry.java
+++ b/core/src/main/java/net/pl3x/map/core/registry/WorldRegistry.java
@@ -46,6 +46,7 @@ public class WorldRegistry extends Registry<@NotNull World> {
         if (world != null) {
             Pl3xMap.api().getEventRegistry().callEvent(new WorldUnloadedEvent(world));
             world.getMarkerTask().cancel();
+            world.getSSETask().cancel();
             //world.getRegionFileWatcher().stop();
             world.cleanup();
         }

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/AbstractDataTask.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/AbstractDataTask.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020-2023 William Blake Galbreath
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package net.pl3x.map.core.renderer.task;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import net.pl3x.map.core.Pl3xMap;
+import net.pl3x.map.core.markers.JsonObjectWrapper;
+import net.pl3x.map.core.markers.marker.Marker;
+import net.pl3x.map.core.scheduler.Task;
+import net.pl3x.map.core.world.World;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class AbstractDataTask extends Task {
+    protected final Gson gson = new GsonBuilder()
+            //.setPrettyPrinting()
+            .disableHtmlEscaping()
+            .serializeNulls()
+            .setLenient()
+            .registerTypeHierarchyAdapter(Marker.class, new Adapter())
+            .create();
+
+    protected final World world;
+    protected final Map<@NotNull String, @NotNull Long> lastUpdated = new HashMap<>();
+    private final ExecutorService executor;
+
+    private CompletableFuture<Void> future;
+    private boolean running;
+
+    public AbstractDataTask(int delay, boolean repeat, World world, String serviceName) {
+        super(delay, repeat);
+        this.world = world;
+        this.executor = Pl3xMap.ThreadFactory.createService(serviceName);
+    }
+
+    @Override
+    public void run() {
+        if (this.running) {
+            return;
+        }
+        this.running = true;
+        this.future = CompletableFuture.runAsync(() -> {
+            try {
+                parse();
+            } catch (Throwable t) {
+                t.printStackTrace();
+            }
+            this.running = false;
+        }, this.executor);
+    }
+
+    @Override
+    public void cancel() {
+        super.cancel();
+        if (this.future != null) {
+            this.future.cancel(true);
+        }
+    }
+
+    public abstract void parse();
+
+    private static class Adapter implements JsonSerializer<@NotNull Marker<?>> {
+        @Override
+        public @NotNull JsonElement serialize(@NotNull Marker<?> marker, @NotNull Type type, @NotNull JsonSerializationContext context) {
+            JsonObjectWrapper wrapper = new JsonObjectWrapper();
+            wrapper.addProperty("type", marker.getType());
+            wrapper.addProperty("data", marker);
+            wrapper.addProperty("options", marker.getOptions());
+            return wrapper.getJsonObject();
+        }
+    }
+}

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateMarkerData.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateMarkerData.java
@@ -61,7 +61,7 @@ public class UpdateMarkerData extends Task {
     private boolean running;
 
     public UpdateMarkerData(@NotNull World world) {
-        super(1, true);
+        super(1 * 20, true);
         this.world = world;
         this.executor = Pl3xMap.ThreadFactory.createService("Pl3xMap-Markers");
     }

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSSEEvents.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSSEEvents.java
@@ -1,0 +1,30 @@
+package net.pl3x.map.core.renderer.task;
+
+import java.util.ArrayList;
+import java.util.List;
+import net.pl3x.map.core.Pl3xMap;
+import net.pl3x.map.core.configuration.Config;
+import net.pl3x.map.core.httpd.HttpdServer;
+import net.pl3x.map.core.markers.layer.Layer;
+import net.pl3x.map.core.markers.marker.Marker;
+import net.pl3x.map.core.world.World;
+
+public class UpdateSSEEvents extends AbstractDataTask {
+    public UpdateSSEEvents(World world) {
+        super(0, true, world, "Pl3xMap-SSE-Events");
+    }
+
+    @Override
+    public void parse() {
+        List<Object> layers = new ArrayList<>();
+
+        this.world.getLayerRegistry().entrySet().forEach(entry -> {
+            String key = entry.getKey();
+            Layer layer = entry.getValue();
+            List<Marker<?>> list = new ArrayList<>(layer.getMarkers());
+            HttpdServer.sendSSE("markers", String.format("{ \"world\": \"%s\", \"key\": \"%s\", \"markers\": %s}", this.world.getName(), key, this.gson.toJson(list)));
+        });
+
+        HttpdServer.sendSSE("players", this.gson.toJson(Pl3xMap.api().getPlayerRegistry().parsePlayers()));
+    }
+}

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSSEEvents.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSSEEvents.java
@@ -16,6 +16,10 @@ public class UpdateSSEEvents extends AbstractDataTask {
 
     @Override
     public void parse() {
+        if (!Config.SSE_EVENTS) {
+            return;
+        }
+
         List<Object> layers = new ArrayList<>();
 
         this.world.getLayerRegistry().entrySet().forEach(entry -> {

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
@@ -64,36 +64,6 @@ public class UpdateSettingsData extends Task {
         }
     }
 
-    private @NotNull List<@NotNull Object> parsePlayers() {
-        if (!PlayersLayerConfig.ENABLED) {
-            return Collections.emptyList();
-        }
-        List<Object> players = new ArrayList<>();
-        Pl3xMap.api().getPlayerRegistry().forEach(player -> {
-            // do not expose hidden players in the json
-            if (player.isHidden() || player.isNPC()) {
-                return;
-            }
-            if (PlayersLayerConfig.HIDE_SPECTATORS && player.isSpectator()) {
-                return;
-            }
-            if (PlayersLayerConfig.HIDE_INVISIBLE && player.isInvisible()) {
-                return;
-            }
-
-            Map<String, Object> playerEntry = new LinkedHashMap<>();
-
-            playerEntry.put("name", player.getDecoratedName());
-            playerEntry.put("uuid", player.getUUID().toString());
-            playerEntry.put("displayName", player.getDecoratedName());
-            playerEntry.put("world", player.getWorld().getName());
-            playerEntry.put("position", player.getPosition());
-
-            players.add(playerEntry);
-        });
-        return players;
-    }
-
     private @NotNull List<@NotNull Map<@NotNull String, @NotNull Object>> parseWorlds() {
         List<Map<String, Object>> worldSettings = new ArrayList<>();
         Pl3xMap.api().getWorldRegistry().entrySet().forEach(entry -> {
@@ -175,7 +145,7 @@ public class UpdateSettingsData extends Task {
         map.put("zoom", zoom);
 
         try {
-            map.put("players", parsePlayers());
+            map.put("players", Pl3xMap.api().getPlayerRegistry().parsePlayers());
             map.put("worldSettings", parseWorlds());
         } catch (Throwable t) {
             t.printStackTrace();

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
@@ -52,7 +52,7 @@ public class UpdateSettingsData extends Task {
             .create();
 
     public UpdateSettingsData() {
-        super(1, true);
+        super(1 * 20, true);
     }
 
     @Override

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
@@ -143,6 +143,7 @@ public class UpdateSettingsData extends Task {
         map.put("maxPlayers", Pl3xMap.api().getMaxPlayers());
         map.put("lang", lang);
         map.put("zoom", zoom);
+        map.put("useSSE", Config.SSE_EVENTS);
 
         try {
             map.put("players", Pl3xMap.api().getPlayerRegistry().parsePlayers());

--- a/core/src/main/java/net/pl3x/map/core/scheduler/Scheduler.java
+++ b/core/src/main/java/net/pl3x/map/core/scheduler/Scheduler.java
@@ -34,7 +34,7 @@ public class Scheduler {
     private boolean ticking;
 
     /**
-     * Tick this scheduler once every second.
+     * Tick this scheduler once every tick.
      */
     public void tick() {
         if (this.ticking) {
@@ -88,7 +88,7 @@ public class Scheduler {
     /**
      * Add task to the scheduler.
      *
-     * @param delay    Delay (in seconds) before task starts
+     * @param delay    Delay (in ticks) before task starts
      * @param runnable Task to add
      */
     public void addTask(int delay, @NotNull Runnable runnable) {
@@ -98,8 +98,8 @@ public class Scheduler {
     /**
      * Add task to the scheduler.
      *
-     * @param delay    Delay (in seconds) before task starts
-     * @param repeat   Delay (in seconds) before task repeats
+     * @param delay    Delay (in ticks) before task starts
+     * @param repeat   Delay (in ticks) before task repeats
      * @param runnable Task to add
      */
     public void addTask(int delay, boolean repeat, @NotNull Runnable runnable) {

--- a/core/src/main/java/net/pl3x/map/core/scheduler/Task.java
+++ b/core/src/main/java/net/pl3x/map/core/scheduler/Task.java
@@ -33,7 +33,7 @@ public abstract class Task implements Runnable {
     /**
      * Creates a new schedulable task.
      *
-     * @param delay Delay (in seconds) before task starts
+     * @param delay Delay (in ticks) before task starts
      */
     public Task(int delay) {
         this(delay, false);
@@ -42,7 +42,7 @@ public abstract class Task implements Runnable {
     /**
      * Creates a new schedulable task.
      *
-     * @param delay  Delay (in seconds) before task starts
+     * @param delay  Delay (in ticks) before task starts
      * @param repeat Whether this task should repeat
      */
     public Task(int delay, boolean repeat) {

--- a/core/src/main/java/net/pl3x/map/core/world/World.java
+++ b/core/src/main/java/net/pl3x/map/core/world/World.java
@@ -174,8 +174,10 @@ public abstract class World extends Keyed {
         Logger.debug("Starting marker task");
         Pl3xMap.api().getScheduler().addTask(this.markerTask);
 
-        Logger.debug("Starting SSE events task");
-        Pl3xMap.api().getScheduler().addTask(this.sseTask);
+        if (Config.SSE_EVENTS) {
+            Logger.debug("Starting SSE events task");
+            Pl3xMap.api().getScheduler().addTask(this.sseTask);
+        }
 
         // load up custom markers
         Logger.debug("Loading custom markers for " + getName());

--- a/core/src/main/java/net/pl3x/map/core/world/World.java
+++ b/core/src/main/java/net/pl3x/map/core/world/World.java
@@ -168,7 +168,7 @@ public abstract class World extends Keyed {
         Pl3xMap.api().getRegionProcessor().addRegions(this, listRegions(false));
 
         Logger.debug("Starting marker task");
-        Pl3xMap.api().getScheduler().addTask(1, true, this.markerTask);
+        Pl3xMap.api().getScheduler().addTask(this.markerTask);
 
         // load up custom markers
         Logger.debug("Loading custom markers for " + getName());

--- a/core/src/main/java/net/pl3x/map/core/world/World.java
+++ b/core/src/main/java/net/pl3x/map/core/world/World.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import javax.imageio.ImageIO;
 import net.pl3x.map.core.Keyed;
 import net.pl3x.map.core.Pl3xMap;
+import net.pl3x.map.core.configuration.Config;
 import net.pl3x.map.core.configuration.PlayersLayerConfig;
 import net.pl3x.map.core.configuration.SpawnLayerConfig;
 import net.pl3x.map.core.configuration.WorldBorderLayerConfig;
@@ -59,6 +60,7 @@ import net.pl3x.map.core.registry.BiomeRegistry;
 import net.pl3x.map.core.registry.Registry;
 import net.pl3x.map.core.renderer.Renderer;
 import net.pl3x.map.core.renderer.task.UpdateMarkerData;
+import net.pl3x.map.core.renderer.task.UpdateSSEEvents;
 import net.pl3x.map.core.util.FileUtil;
 import net.pl3x.map.core.util.Mathf;
 import org.jetbrains.annotations.NotNull;
@@ -87,6 +89,7 @@ public abstract class World extends Keyed {
     private final RegionModifiedState regionModifiedState;
     //private final RegionFileWatcher regionFileWatcher;
     private final UpdateMarkerData markerTask;
+    private final UpdateSSEEvents sseTask;
     private final Map<@NotNull String, Renderer.@NotNull Builder> renderers = new LinkedHashMap<>();
 
     public World(@NotNull String name, long seed, @NotNull Point spawn, @NotNull Type type, @NotNull Path regionDirectory) {
@@ -122,6 +125,7 @@ public abstract class World extends Keyed {
         this.regionModifiedState = new RegionModifiedState(this);
         //this.regionFileWatcher = new RegionFileWatcher(this);
         this.markerTask = new UpdateMarkerData(this);
+        this.sseTask = new UpdateSSEEvents(this);
     }
 
     protected void init() {
@@ -170,6 +174,9 @@ public abstract class World extends Keyed {
         Logger.debug("Starting marker task");
         Pl3xMap.api().getScheduler().addTask(this.markerTask);
 
+        Logger.debug("Starting SSE events task");
+        Pl3xMap.api().getScheduler().addTask(this.sseTask);
+
         // load up custom markers
         Logger.debug("Loading custom markers for " + getName());
         for (Path file : getCustomMarkerFiles()) {
@@ -212,6 +219,10 @@ public abstract class World extends Keyed {
 
     public @NotNull UpdateMarkerData getMarkerTask() {
         return this.markerTask;
+    }
+
+    public @NotNull UpdateSSEEvents getSSETask() {
+        return this.sseTask;
     }
 
     public @NotNull Map<@NotNull String, Renderer.@NotNull Builder> getRenderers() {

--- a/fabric/src/main/java/net/pl3x/map/fabric/client/manager/TileManager.java
+++ b/fabric/src/main/java/net/pl3x/map/fabric/client/manager/TileManager.java
@@ -64,7 +64,7 @@ public class TileManager {
         // update once next tick
         this.mod.getScheduler().addTask(0, this::update);
         // setup repeating task to update every 5 seconds
-        this.task = new Task(5, true) {
+        this.task = new Task(5 * 20, true) {
             @Override
             public void run() {
                 update();

--- a/fabric/src/main/java/net/pl3x/map/fabric/server/Pl3xMapFabricServer.java
+++ b/fabric/src/main/java/net/pl3x/map/fabric/server/Pl3xMapFabricServer.java
@@ -73,7 +73,6 @@ public class Pl3xMapFabricServer extends Pl3xMap implements DedicatedServerModIn
     private FabricServerAudiences adventure;
 
     private boolean firstTick = true;
-    private int tick;
 
     private FabricNetwork network;
 
@@ -94,10 +93,7 @@ public class Pl3xMapFabricServer extends Pl3xMap implements DedicatedServerModIn
                 Pl3xMap.api().getEventRegistry().callEvent(new ServerLoadedEvent());
                 this.firstTick = false;
             }
-            if (this.tick++ >= 20) {
-                this.tick = 0;
-                getScheduler().tick();
-            }
+            getScheduler().tick();
         });
 
         ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {

--- a/webmap/src/Pl3xMap.ts
+++ b/webmap/src/Pl3xMap.ts
@@ -74,6 +74,10 @@ export class Pl3xMap {
         getJSON('tiles/settings.json').then((json): void => {
             this._settings = json as Settings;
 
+            if (!this._settings.useSSE) {
+                Pl3xMap.instance.eventSource.close();
+            }
+
             if (Pl3xMap.instance.eventSource.readyState === EventSource.CLOSED) {
                 this.playerManager.update(this._settings.players);
             }

--- a/webmap/src/layergroup/MarkerLayer.ts
+++ b/webmap/src/layergroup/MarkerLayer.ts
@@ -115,45 +115,51 @@ export class MarkerLayer extends L.LayerGroup {
     }
 
     update(world: World): void {
+        if (Pl3xMap.instance.eventSource.readyState !== EventSource.CLOSED) {
+            return;
+        }
+
         getJSON(`tiles/${world.name}/markers/${this._key}.json`)
-            .then((json): void => {
-                //this.clearLayers(); // do not just clear markers, remove the ones that are missing
-                const toRemove: Set<string> = new Set(this._markers.keys());
+            .then((json): void => this.updateMarkers(json, world));
+    }
 
-                for (const index in Object.keys(json)) {
-                    const existing: Marker | undefined = this._markers.get(json[index].data.key);
-                    if (existing) {
-                        // update
-                        const data = json[index];
-                        const options: MarkerOptions | undefined = isset(data.options) ? new MarkerOptions(data.options) : undefined;
-                        existing.update(data.data, options);
-                        // do not remove this marker
-                        toRemove.delete(existing.key);
-                    } else {
-                        // new marker
-                        const marker: Marker | undefined = this.parseMarker(json[index]);
-                        if (marker) {
-                            this._markers.set(marker.key, marker);
-                            marker.marker.addTo(this);
-                            // inform the events
-                            fireCustomEvent('markeradded', marker);
-                        }
-                    }
+    updateMarkers(json: any, world: World): void {
+        //this.clearLayers(); // do not just clear markers, remove the ones that are missing
+        const toRemove: Set<string> = new Set(this._markers.keys());
+
+        for (const index in Object.keys(json)) {
+            const existing: Marker | undefined = this._markers.get(json[index].data.key);
+            if (existing) {
+                // update
+                const data = json[index];
+                const options: MarkerOptions | undefined = isset(data.options) ? new MarkerOptions(data.options) : undefined;
+                existing.update(data.data, options);
+                // do not remove this marker
+                toRemove.delete(existing.key);
+            } else {
+                // new marker
+                const marker: Marker | undefined = this.parseMarker(json[index]);
+                if (marker) {
+                    this._markers.set(marker.key, marker);
+                    marker.marker.addTo(this);
+                    // inform the events
+                    fireCustomEvent('markeradded', marker);
                 }
+            }
+        }
 
-                toRemove.forEach((key: string): void => {
-                    // remove players not in updated settings file
-                    const marker: Marker | undefined = this._markers.get(key);
-                    if (marker) {
-                        this._markers.delete(key);
-                        marker.marker.remove();
-                        this.removeLayer(marker.marker);
-                        fireCustomEvent('markerremoved', marker);
-                    }
-                });
+        toRemove.forEach((key: string): void => {
+            // remove players not in updated settings file
+            const marker: Marker | undefined = this._markers.get(key);
+            if (marker) {
+                this._markers.delete(key);
+                marker.marker.remove();
+                this.removeLayer(marker.marker);
+                fireCustomEvent('markerremoved', marker);
+            }
+        });
 
-                this._timer = setTimeout(() => this.update(world), this._updateInterval);
-            });
+        this._timer = setTimeout(() => this.update(world), this._updateInterval);
     }
 
     unload(): void {

--- a/webmap/src/player/PlayerManager.ts
+++ b/webmap/src/player/PlayerManager.ts
@@ -17,10 +17,10 @@ export class PlayerManager {
         this._pl3xmap = pl3xmap;
     }
 
-    public update(settings: Settings): void {
+    public update(players: Player[]): void {
         const toRemove: Set<string> = new Set(this._players.keys());
 
-        settings.players.forEach((data: Player): void => {
+        players.forEach((data: Player): void => {
             const existing: Player | undefined = this._players.get(data.uuid);
             if (existing) {
                 // update existing

--- a/webmap/src/settings/Settings.ts
+++ b/webmap/src/settings/Settings.ts
@@ -10,14 +10,16 @@ export class Settings {
     private readonly _maxPlayers: number;
     private readonly _lang: Lang;
     private readonly _zoom: Zoom;
+    private readonly _useSSE: boolean;
     private readonly _players: Player[];
     private readonly _worldSettings: WorldSettings[];
 
-    constructor(format: string, maxPlayers: number, lang: Lang, zoom: Zoom, players: Player[], worldSettings: WorldSettings[]) {
+    constructor(format: string, maxPlayers: number, lang: Lang, zoom: Zoom, useSSE: boolean, players: Player[], worldSettings: WorldSettings[]) {
         this._format = format;
         this._maxPlayers = maxPlayers;
         this._lang = lang;
         this._zoom = zoom;
+        this._useSSE = useSSE;
         this._players = players;
         this._worldSettings = worldSettings;
     }
@@ -36,6 +38,10 @@ export class Settings {
 
     get zoom(): Zoom {
         return this._zoom;
+    }
+
+    get useSSE(): boolean {
+        return this._useSSE;
     }
 
     get players(): Player[] {


### PR DESCRIPTION
## Overview

This pull request introduces the integration of [Server-Sent Events (SSE)](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) into our internal webserver, enabling real-time data updates for our webmap. Using SSE we can achieve seamless real-time updates, significantly enhancing the user experience.

## Details
Here are the key features and functionalities that this pull request will bring:
1. SSE provides real-time player position updates, allowing the webmap to track and display accurate player positions as they rotate and run around.
1. SSE facilitates immediate marker updates, making sure that any adjustments or additions to markers are instantly reflected on the webmap.
1. In cases where SSE connections are closed or nonexistent, the system gracefully falls back to updating through the old system, which is done through files.
1. When an SSE connection is established, the frontend bypasses file-based checks entirely.

### What if I want this but I have the internal server off???

You can still get the advantages of this change if you use an external server. Just re-enable the internal web server under a different port and setting up a reverse proxy that points only to the `/sse` endpoint. This means you can gain the functionality of real-time data updates while the server is running, while also keeping the map available to view, even if the minecraft server is offline.

<details>

<summary><b><code>/sse</code> reverse proxy Caddy example:</b></summary>

```css
map.example.com {
    root * /var/www/map.example.com/
    file_server

    handle_path /sse* {
        rewrite * /sse{uri}
        reverse_proxy localhost:1234
    }

    @gz {
        path *.gz
    }

    handle @gz {
        header Content-Encoding gzip
    }
}
```

</details>

## TODO:

- [ ] adjust how often the SSE task should run (currently every tick, maybe increase?)
- [ ] better SSE disconnection handling
- [ ] better SSE handling in webmap
- [ ] fallback to old system if data from SSE takes longer than a second?
- [ ] clean up implementation
- [ ] remove `SSE_EVENTS` option
- [ ] anything else i think of
